### PR TITLE
Switch travis credentials to autotrace/autotrace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ notifications:
   email: false
 
 sudo: required
+dist: xenial           # ubuntu 16.06, thankfully ignored in osx.
 
 addons:
   apt:
@@ -41,7 +42,7 @@ before_install:
   - test "$TRAVIS_OS_NAME" != osx || brew update
   - test "$TRAVIS_OS_NAME" != osx || for pkg in gettext intltool glib libtool autoconf automake pkg-config; do brew install $pkg || brew upgrade $pkg; done
   - test "$TRAVIS_OS_NAME" != osx || brew install imagemagick pstoedit
-  - test "$TRAVIS_OS_NAME" != osx || brew install graphicsmagick		# this one has magick/api.h, it needs MAGIC_* with configure below, sigh.
+  - test "$TRAVIS_OS_NAME" != osx || brew install graphicsmagick            # this one has magick/api.h, it needs MAGIC_* with configure below, sigh.
 
 before_script:
   - test "$TRAVIS_OS_NAME" != osx || export PATH=${PATH}:/usr/local/opt/gettext/bin
@@ -57,7 +58,7 @@ script:
   - test "$TRAVIS_OS_NAME" != linux || LD_LIBRARY_PATH=.libs ldd .libs/autotrace || true
   - "./autotrace -v"
   - (cd distribute; sh ./distribute.sh)
-# avoid silly error: Skipping a deployment with the releases provider because this is not a tagged commit
+  # avoid silly error: Skipping a deployment with the releases provider because this is not a tagged commit
   - test -n "$TRAVIS_TAG" || export TRAVIS_TAG="travis-$(date +%Y%m%d).$TRAVIS_BUILD_NUMBER"
   - env || true
 
@@ -65,17 +66,20 @@ script:
 deploy:
   provider: releases
   api_key:
-    secure: szvq+YLTUow2NRYcf9hw/SZAjh4qg7Ei71QP9Sjt0VuTQLH67a0OdKZqc8MDBrxo3O3jxQEryRWmbP/F3FT7ufwbvHc0c/GNcalOQ0l+q3lFlYAIb8L2a8EIKNk2XPMHiUdlbRm98mMLemWR+FcvUKwUqUSOUaUOcGPdNcli2eego7CbR6LksN0+8Aq5+V8nlVSSQqRYfjE+/vOLNIspMTR2sjCOM8AwIWrChvMtP1Q+wthR18tq95bU9/KhnmI6Zzl5jGfR9IgxuECncZywGREylKV/HTxBleTPprgAaSWdmUshFeNJn3LRtqruv3O2lkLu/Fcjgb+g/YOk+kfLi8Dqr6qlaJd1DHu4ea3QQK5cSVnFqSwbG/51+X3aHjjIShj5MGh6ca0870OHdBgMJASSecwfkiukiDwJB6HvX8MNrajFtG+8WJ9+oiQafzNsQY/L0dLWQx80hbWkcj3fKaRkyT5Tcy9a1+Eu2D5nzlRGbDuio/9opTRN0T5p5QTsMmo7dW94HalZ+JLovKZtKpbGqRUG9Bpk2icPnPDFVjTajkaP0blfuWtkbR+wnsqX0SiqxBrt07zac+wXi741wj72wsDtdGJJJg9gj+kEJ7lNr1hDe026/0ql51xz39vyck/1kUGmcdj3aKqgl+UB3kH9+Z7pr13Mf8uJEHa7p4g=
+    ## repo autotrace/autotrace with public_repo
+    secure: X39eGZMQReXByDuPlRzbpDj1AAWFgHEots1seZOyMAOed32we0HRRHBuRlYTuSyT6vDvTY9FFbYmI2qRYMlkMUfpGnxlsC/PhIdej3OYdvpQTjFWPbrgnhT8ugWu0CnafaxD3XCR08dkcS498JsmgnQ+PbvidE0JhvAXsCNlD1A=
+    ## for repo jnweiger/autotrace
+    # secure: szvq+YLTUow2NRYcf9hw/SZAjh4qg7Ei71QP9Sjt0VuTQLH67a0OdKZqc8MDBrxo3O3jxQEryRWmbP/F3FT7ufwbvHc0c/GNcalOQ0l+q3lFlYAIb8L2a8EIKNk2XPMHiUdlbRm98mMLemWR+FcvUKwUqUSOUaUOcGPdNcli2eego7CbR6LksN0+8Aq5+V8nlVSSQqRYfjE+/vOLNIspMTR2sjCOM8AwIWrChvMtP1Q+wthR18tq95bU9/KhnmI6Zzl5jGfR9IgxuECncZywGREylKV/HTxBleTPprgAaSWdmUshFeNJn3LRtqruv3O2lkLu/Fcjgb+g/YOk+kfLi8Dqr6qlaJd1DHu4ea3QQK5cSVnFqSwbG/51+X3aHjjIShj5MGh6ca0870OHdBgMJASSecwfkiukiDwJB6HvX8MNrajFtG+8WJ9+oiQafzNsQY/L0dLWQx80hbWkcj3fKaRkyT5Tcy9a1+Eu2D5nzlRGbDuio/9opTRN0T5p5QTsMmo7dW94HalZ+JLovKZtKpbGqRUG9Bpk2icPnPDFVjTajkaP0blfuWtkbR+wnsqX0SiqxBrt07zac+wXi741wj72wsDtdGJJJg9gj+kEJ7lNr1hDe026/0ql51xz39vyck/1kUGmcdj3aKqgl+UB3kH9+Z7pr13Mf8uJEHa7p4g=
   file: distribute/out/autotrace*
   file_glob: true
   overwrite: true
   skip_cleanup: true
   'on':
-    repo: jnweiger/autotrace
-# tags: false -- allows also to deploy with untagged-XXXXX tag names. Was a default previously.
+    repo: autotrace/autotrace
+    # tags: false -- allows also to deploy with untagged-XXXXX tag names. Was a default previously.
     tags: true
     all_branches: true
-# if TRAVIS_BRANCH is travis-XXXXX.yy then a build was triggered while creating TRAVIS_TAG. That is a travis bug and should never happen.
+    ## if TRAVIS_BRANCH is travis-XXXXX.yy then a build was triggered while creating TRAVIS_TAG. That is a travis bug and should never happen.
     condition: '"$TRAVIS_BRANCH" != "$TRAVIS_TAG"'
     branches:
       only:


### PR DESCRIPTION
Using a new encrypted release token.

Having the repo encoded inside .travis-ci.yml is a bit silly, everytime when merging into another repo, this needs manual change or the travis build will not work there. 

Maybe we can find a syntax that allows multiple deploy.release sections, or  keep multiple api-keys in the env section. Will continue experiments later. For now it seems to work nicely.