### PR TITLE
help text formatting and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,60 +60,94 @@ Program comes from two parts: command and library.
 
 Here the options you can use in the command:
 
-    Usage: autotrace.exe [options] <input_name>.
-    Options:<input_name> should be a supported image.
-      You can use `--' or `-' to start an option.
+    Usage: autotrace [options] <input_file_name>
+    Options:<input_file_name> must be a supported image file.
+      You can use '--' or '-' to start an option.
       You can use any unambiguous abbreviation for an option name.
-      You can separate option names and values with `=' or ` '.
-    background-color <hexadecimal>: the color of the background that
-      should be ignored, for example FFFFFF;
-      default is no background color.
-    centerline: trace a character's centerline, rather than its outline.
-    color-count <unsigned>: number of colors a color bitmap is reduced to,
-      it does not work on gray scale, allowed are 1..256;
-      default is 0, that means not color reduction is done.
-    corner-always-threshold <angle-in-degrees>: if the angle at a pixel is
-      less than this, it is considered a corner, even if it is within
-      `corner-surround' pixels of another corner; default is 60.
-    corner-surround <unsigned>: number of pixels on either side of a
-      point to consider when determining if that point is a corner;
-      default is 4.
-    corner-threshold <angle-in-degrees>: if a pixel, its predecessor(s),
-      and its successor(s) meet at an angle smaller than this, it's a
-      corner; default is 100.
-    despeckle-level <unsigned>: 0..20; default is no despeckling.
-    despeckle-tightness <real>: 0.0..8.0; default is 2.0.
-    dpi <unsigned>: The dots per inch value in the input image, affects scaling
-      of mif output image
-    error-threshold <real>: subdivide fitted curves that are off by
-      more pixels than this; default is 2.0.
-    filter-iterations <unsigned>: smooth the curve this many times
-      before fitting; default is 4.
-    input-format:  TGA, PBM, PNM, PGM, PPM or BMP.
-    help: print this message.
-    line-reversion-threshold <real>: if a spline is closer to a straight
-      line than this, weighted by the square of the curve length, keep it a
-      straight line even if it is a list with curves; default is .01.
-    line-threshold <real>: if the spline is not more than this far away
-      from the straight line defined by its endpoints,
-      then output a straight line; default is 1.
-    list-output-formats: print a list of support output formats to stderr.
-    list-input-formats:  print a list of support input formats to stderr.
-    log: write detailed progress reports to <input_name>.log.
-    output-file <filename>: write to <filename>
-    output-format <format>: use format <format> for the output file
-    output-format <format>: use format <format> for the output file
-      eps, ai, p2e, sk, svg, fig, swf, emf, mif, er, dxf, epd, pdf, cgm or dr2d
-      can be used.
-    preserve-width: whether to preserve line width prior to thinning.\n\
-    remove-adjacent-corners: remove corners that are adjacent.
-    tangent-surround <unsigned>: number of points on either side of a
-      point to consider when computing the tangent at that point; default is 3.
-    report-progress: report tracing status in real time.
-    debug-arch: print the type of cpu.
-    debug-bitmap: dump loaded bitmap to <input_name>.bitmap.
-    version: print the version number of this program.
-    width-weight-factor: weight factor for fitting the line width.
+      You can separate option names and values with '=' or ' '.
+
+    -background-color <hexadecimal>: the color of the background that should
+        be ignored, for example FFFFFF; default is no background color.
+
+    -centerline: trace a character's centerline, rather than its outline.
+
+    -charcode <unsigned>: code of character to load from GF font file.
+
+    -color-count <unsigned>: number of colors a color bitmap is reduced to,
+        it does not work on grayscale, allowed are 1..256;
+        default is 0, that means no color reduction is done.
+
+    -corner-always-threshold <angle-in-degrees>: if the angle at a pixel is
+        less than this, it is considered a corner, even if it is within
+        `corner-surround' pixels of another corner; default is 60.
+
+    -corner-surround <unsigned>: number of pixels on either side of a
+        point to consider when determining if that point is a corner;
+        default is 4.
+
+    -corner-threshold <angle-in-degrees>: if a pixel, its predecessor(s),
+        and its successor(s) meet at an angle smaller than this, it's a
+        corner; default is 100.
+
+    -despeckle-level <unsigned>: 0..20; default is 0: no despeckling.
+
+    -despeckle-tightness <real>: 0.0..8.0; default is 2.0.
+
+    -dpi <unsigned>: The dots per inch value in the input image, affects scaling
+        of mif output image
+
+
+    -error-threshold <real>: subdivide fitted curves that are off by
+        more pixels than this; default is 2.0.
+
+    -filter-iterations <unsigned>: smooth the curve this many times
+        before fitting; default is 4.
+
+    -input-format: Available formats: ppm, png, pbm, pnm, bmp, tga, pgm, gf.
+
+    -help: print this message.
+
+    -line-reversion-threshold <real>: if a spline is closer to a straight
+        line than this, weighted by the square of the curve length, keep it a
+        straight line even if it is a list with curves; default is .01.
+
+    -line-threshold <real>: if the spline is not more than this far away
+        from the straight line defined by its endpoints,
+        then output a straight line; default is 1.
+
+    -list-output-formats: print a list of supported output formats to stderr.
+
+    -list-input-formats: print a list of supported input formats to stderr.
+
+    -log: write detailed progress reports to <input_name>.log.
+
+    -noise-removal <real>:: 0.0..1.0; default is 0.99.
+
+    -output-file <filename>: write to <filename>
+
+    -output-format <format>: use format <format> for the output file. Available formats:
+        rpl, tk, cfdg, xfig, plot, svg, plot-svg, gschem, gmfa, text, epd, tek, rib, sk, plot-tek, gmfb, pcl, txt, asy, plot-pcl, tex, gnuplot, cairo, dat, plot-hpgl, lwo, pcb, xml, dr2d, pov, dxf_14, eps, tfig, mp, meta, java1, hpgl, ai, cgm, pdf, latex2e, ps2ai, p2e, java2, pic, svm, plot-cgm, plot-ai, plt, noixml, vtk, tgif, idraw, fig, emf, plot-fig, kil, er, m, dxf, obj, ugs, pcbfill, mif, mma, java, gcode, c, dxf_s, ild, mpost, pcbi
+
+    -preserve-width: preserve line width prior to thinning.
+
+    -remove-adjacent-corners: remove corners that are adjacent.
+
+    -tangent-surround <unsigned>: number of points on either side of a
+        point to consider when computing the tangent at that point; default is 3.
+
+    -report-progress: report tracing status in real time.
+
+    -debug-arch: print the type of cpu.
+
+    -debug-bitmap: dump loaded bitmap to <input_name>.bitmap.ppm or pgm.
+
+    -version: print the version number of this program.
+
+    -width-weight-factor <real>: weight factor for fitting the linewidth.
+
+
+    You can get the source code of autotrace from 
+    https://github.com/autotrace/autotrace
 
 The library is named libautotrace. About the usage of the library
 see `autotrace.h`.

--- a/autotrace  compile notes.txt
+++ b/autotrace  compile notes.txt
@@ -1,0 +1,45 @@
+
+
+To run autotrace on mac
+
+input.c
+
+changes png.h to imput-png.h
+
+it exists here
+
+/Users/tbatters/homebrew/include/png.h
+/Users/tbatters/homebrew/Cellar/libpng/1.6.37/include/libpng16/png.h
+/Users/tbatters/homebrew/Cellar/libpng/1.6.37/include/png.h
+
+
+add this to LDFLAGS
+CPPFLAGS
+
+-I/Users/tbatters/homebrew/include/ 
+
+
+add to linker
+-L/Users/tbatters/homebrew/lib
+-L/Users/tbatters/homebrew/opt/lcms2/lib
+-L/Users/tbatters/homebrew/Cellar/libtool/2.4.6_1/lib
+
+
+ld: library not found for -lltdl
+this error is looking for libtool it is here--> add it to LDFLAGS
+-L/Users/tbatters/homebrew/Cellar/libtool/2.4.6_1/lib
+
+
+
+
+
+export LDFLAGS="-Lxxx"
+
+
+gcc -g -O2 -o .libs/autotrace src/atou.o src/main.o -Wl,-framework -Wl,CoreFoundation -L/Users/tbatters/homebrew/Cellar/libtool/2.4.6_1/lib  -L/Users/tbatters/homebrew/opt/lcms2/lib  -L/Users/tbatters/homebrew/opt/gettext/lib ./.libs/libautotrace.dylib -L/Users/tbatters/homebrew/Cellar/graphicsmagick/1.3.35/lib /Users/tbatters/homebrew/Cellar/graphicsmagick/1.3.35/lib/libGraphicsMagick.dylib -L/Users/tbatters/homebrew/opt/freetype/lib -L/Users/tbatters/homebrew/Cellar/libtool/2.4.6_1/share/libtool -llcms2 -lfreetype -lbz2 -lltdl -lpthread -L/Users/tbatters/homebrew/Cellar/libpng/1.6.37/lib -lpng16 -lz -L/Users/tbatters/homebrew/Cellar/pstoedit/3.75/lib -lpstoedit -lstdc++ -ldl -L/Users/tbatters/homebrew/Cellar/glib/2.64.2_1/lib -lgmodule-2.0 -lgthread-2.0 -lgobject-2.0 -lglib-2.0 -lintl -lm
+
+
+
+gcc -g -O2 -o .libs/autotrace src/atou.o src/main.o -Wl,-framework -Wl,CoreFoundation -L/Users/tbatters/homebrew/Cellar/libtool/2.4.6_1/lib  -L/Users/tbatters/homebrew/opt/lcms2/lib -L/Users/tbatters/homebrew/opt/gettext/lib ./.libs/libautotrace.dylib -L/Users/tbatters/homebrew/Cellar/graphicsmagick/1.3.35/lib /Users/tbatters/homebrew/Cellar/graphicsmagick/1.3.35/lib/libGraphicsMagick.dylib -L/Users/tbatters/homebrew/opt/freetype/lib -llcms2 -lfreetype -lbz2 -lltdl -lpthread -L/Users/tbatters/homebrew/Cellar/libpng/1.6.37/lib -lpng16 -lz -L/Users/tbatters/homebrew/Cellar/pstoedit/3.75/lib -lpstoedit -lstdc++ -ldl -L/Users/tbatters/homebrew/Cellar/glib/2.64.2_1/lib -lgmodule-2.0 -lgthread-2.0 -lgobject-2.0 -lglib-2.0 -lintl -lm
+
+gcc -g -O2 -o .libs/autotrace src/atou.o src/main.o -Wl,-framework -Wl,CoreFoundation -L/Users/tbatters/homebrew/Cellar/libtool/2.4.6_1/lib -L/Users/tbatters/homebrew/opt/lcms2/lib  -L/Users/tbatters/homebrew/opt/gettext/lib ./.libs/libautotrace.dylib -L/Users/tbatters/homebrew/Cellar/graphicsmagick/1.3.35/lib /Users/tbatters/homebrew/Cellar/graphicsmagick/1.3.35/lib/libGraphicsMagick.dylib -L/Users/tbatters/homebrew/opt/freetype/lib -llcms2 -lfreetype -lbz2 -lltdl -lpthread -L/Users/tbatters/homebrew/Cellar/libpng/1.6.37/lib -lpng16 -lz -L/Users/tbatters/homebrew/Cellar/pstoedit/3.75/lib -lpstoedit -lstdc++ -ldl -L/Users/tbatters/homebrew/Cellar/glib/2.64.2_1/lib -lgmodule-2.0 -lgthread-2.0 -lgobject-2.0 -lglib-2.0 -lintl -lm

--- a/src/cmdline.h
+++ b/src/cmdline.h
@@ -31,10 +31,10 @@
         }								\
       else								\
         {								\
-          fprintf (stderr, "Usage: %s [options] <image_name>.\n", argv[0]);\
+          fprintf (stderr, "Usage: %s [options] <image_file_name>\n", argv[0]);\
           fprintf (stderr, "(%s.)\n", optind == argc ? "Missing <image_name>"\
-                                      : "Too many <image_name>s");	\
-          fputs ("For more information, use ``-help''.\n", stderr);	\
+                                      : "Too many <image_file_name>s");	\
+          fputs ("For more information, use ''-help''.\n", stderr);	\
           exit (1);							\
         }								\
       return NULL; /* stop warnings */					\
@@ -42,9 +42,9 @@
   while (0)
 
 #define GETOPT_USAGE \
-"  You can use `--' or `-' to start an option.\n\
+"  You can use '--' or '-' to start an option.\n\
   You can use any unambiguous abbreviation for an option name.\n\
-  You can separate option names and values with `=' or ` '.\n\
+  You can separate option names and values with '=' or ' '.\n\
 "
 
 /* What to pass to `strtok' to separate different arguments to an

--- a/src/main.c
+++ b/src/main.c
@@ -187,57 +187,58 @@ int main(int argc, char *argv[])
 /* Reading the options.  */
 
 #define USAGE1 "Options:\
-<input_name> should be a supported image.\n"\
+<input_name> must be a supported image file.\n"\
   GETOPT_USAGE								\
-"background-color <hexadezimal>: the color of the background that\n\
-  should be ignored, for example FFFFFF;\n\
-  default is no background color.\n\
-centerline: trace a character's centerline, rather than its outline.\n\
-charcode <unsigned>: code of character to load from GF font file.\n\
-color-count <unsigned>: number of colors a color bitmap is reduced to,\n\
-  it does not work on grayscale, allowed are 1..256;\n\
-  default is 0, that means not color reduction is done.\n\
-corner-always-threshold <angle-in-degrees>: if the angle at a pixel is\n\
-  less than this, it is considered a corner, even if it is within\n\
-  `corner-surround' pixels of another corner; default is 60.\n\
-corner-surround <unsigned>: number of pixels on either side of a\n\
-  point to consider when determining if that point is a corner;\n\
-  default is 4.\n\
-corner-threshold <angle-in-degrees>: if a pixel, its predecessor(s),\n\
-  and its successor(s) meet at an angle smaller than this, it's a\n\
-  corner; default is 100.\n\
-despeckle-level <unsigned>: 0..20; default is no despeckling.\n\
-despeckle-tightness <real>: 0.0..8.0; default is 2.0.\n\
-dpi <unsigned>: The dots per inch value in the input image, affects scaling\n\
-  of mif output image\n"
-#define USAGE2 "error-threshold <real>: subdivide fitted curves that are off by\n\
-  more pixels than this; default is 2.0.\n\
-filter-iterations <unsigned>: smooth the curve this many times\n\
-  before fitting; default is 4.\n\
-input-format:  %s. \n\
-help: print this message.\n\
-line-reversion-threshold <real>: if a spline is closer to a straight\n\
-  line than this, weighted by the square of the curve length, keep it a\n\
-  straight line even if it is a list with curves; default is .01.\n\
-line-threshold <real>: if the spline is not more than this far away\n\
-  from the straight line defined by its endpoints,\n\
-  then output a straight line; default is 1.\n\
-list-output-formats: print a list of support output formats to stderr.\n\
-list-input-formats:  print a list of support input formats to stderr.\n\
-log: write detailed progress reports to <input_name>.log.\n\
-noise-removal <real>:: 0.0..1.0; default is 0.99.\n\
-output-file <filename>: write to <filename>\n\
-output-format <format>: use format <format> for the output file\n\
-  %s can be used.\n\
-preserve-width: whether to preserve line width prior to thinning.\n\
-remove-adjacent-corners: remove corners that are adjacent.\n\
-tangent-surround <unsigned>: number of points on either side of a\n\
-  point to consider when computing the tangent at that point; default is 3.\n\
-report-progress: report tracing status in real time.\n\
-debug-arch: print the type of cpu.\n\
-debug-bitmap: dump loaded bitmap to <input_name>.bitmap.ppm or pgm.\n\
-version: print the version number of this program.\n\
-width-weight-factor <real>: weight factor for fitting the linewidth.\n\
+"\n\
+-background-color <hexadecimal>: the color of the background that should\n\
+    be ignored, for example FFFFFF; default is no background color.\n\n\
+-centerline: trace a character's centerline, rather than its outline.\n\n\
+-charcode <unsigned>: code of character to load from GF font file.\n\n\
+-color-count <unsigned>: number of colors a color bitmap is reduced to,\n\
+    it does not work on grayscale, allowed are 1..256;\n\
+    default is 0, that means no color reduction is done.\n\n\
+-corner-always-threshold <angle-in-degrees>: if the angle at a pixel is\n\
+    less than this, it is considered a corner, even if it is within\n\
+    `corner-surround' pixels of another corner; default is 60.\n\n\
+-corner-surround <unsigned>: number of pixels on either side of a\n\
+    point to consider when determining if that point is a corner;\n\
+    default is 4.\n\n\
+-corner-threshold <angle-in-degrees>: if a pixel, its predecessor(s),\n\
+    and its successor(s) meet at an angle smaller than this, it's a\n\
+    corner; default is 100.\n\n\
+-despeckle-level <unsigned>: 0..20; default is 0: no despeckling.\n\n\
+-despeckle-tightness <real>: 0.0..8.0; default is 2.0.\n\n\
+-dpi <unsigned>: The dots per inch value in the input image, affects scaling\n\
+    of mif output image\n\n"
+#define USAGE2 "\n\
+-error-threshold <real>: subdivide fitted curves that are off by\n\
+    more pixels than this; default is 2.0.\n\n\
+-filter-iterations <unsigned>: smooth the curve this many times\n\
+    before fitting; default is 4.\n\n\
+-input-format: Available formats: %s.\n\n\
+-help: print this message.\n\n\
+-line-reversion-threshold <real>: if a spline is closer to a straight\n\
+    line than this, weighted by the square of the curve length, keep it a\n\
+    straight line even if it is a list with curves; default is .01.\n\n\
+-line-threshold <real>: if the spline is not more than this far away\n\
+    from the straight line defined by its endpoints,\n\
+    then output a straight line; default is 1.\n\n\
+-list-output-formats: print a list of supported output formats to stderr.\n\n\
+-list-input-formats: print a list of supported input formats to stderr.\n\n\
+-log: write detailed progress reports to <input_name>.log.\n\n\
+-noise-removal <real>:: 0.0..1.0; default is 0.99.\n\n\
+-output-file <filename>: write to <filename>\n\n\
+-output-format <format>: use format <format> for the output file. Available formats:\n\
+    %s\n\n\
+-preserve-width: preserve line width prior to thinning.\n\n\
+-remove-adjacent-corners: remove corners that are adjacent.\n\n\
+-tangent-surround <unsigned>: number of points on either side of a\n\
+    point to consider when computing the tangent at that point; default is 3.\n\n\
+-report-progress: report tracing status in real time.\n\n\
+-debug-arch: print the type of cpu.\n\n\
+-debug-bitmap: dump loaded bitmap to <input_name>.bitmap.ppm or pgm.\n\n\
+-version: print the version number of this program.\n\n\
+-width-weight-factor <real>: weight factor for fitting the linewidth.\n\n\
 "
 
 /* We return the name of the image to process.  */
@@ -349,7 +350,7 @@ static char *read_command_line(int argc, char *argv[], at_fitting_opts_type * fi
 
     else if (ARGUMENT_IS("help")) {
       char *ishortlist, *oshortlist;
-      fprintf(stderr, _("Usage: %s [options] <input_file_name>.\n"), argv[0]);
+      fprintf(stderr, _("Usage: %s [options] <input_file_name>\n"), argv[0]);
       fprintf(stderr, USAGE1);
       fprintf(stderr, USAGE2, ishortlist = at_input_shortlist(), oshortlist = at_output_shortlist());
       free(ishortlist);

--- a/src/output-eps.c
+++ b/src/output-eps.c
@@ -181,6 +181,7 @@ int output_eps_writer(FILE * ps_file, gchar * name, int llx, int lly, int urx, i
     return result;
 
   OUT_LINE("1 setlinecap");       /* set shape of line ends for stroke (0=butt,1=round, 2=square) */
+  OUT_LINE("1 setlinejoin");       /* set shape of corners for stroke (0=miter,1=round, 2=bevel */
 
   out_splines(ps_file, shape);
 

--- a/src/output-eps.c
+++ b/src/output-eps.c
@@ -180,6 +180,8 @@ int output_eps_writer(FILE * ps_file, gchar * name, int llx, int lly, int urx, i
   if (result != 0)
     return result;
 
+  OUT_LINE("1 setlinecap");       /* set shape of line ends for stroke (0=butt,1=round, 2=square) */
+
   out_splines(ps_file, shape);
 
   OUT_LINE("%%Trailer");


### PR DESCRIPTION
Tidied up the help text and usage texts by adding some space between options. Corrected a few typos in help text.