### PR TITLE
Use printf instead of echo -n

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -5,20 +5,19 @@ test -n "$srcdir" || srcdir=.
 
 cd $srcdir
 
-echo -n "checking for pkg-config... "
+printf "%s" "checking for pkg-config... "
 which pkg-config || {
 	echo "*** No pkg-config found, please install it ***"
 	exit 1
 }
 
-echo -n "checking for autoreconf... "
+printf "%s" "checking for autoreconf... "
 which autoreconf || {
 	echo "*** No autoreconf found, please install it ***"
 	exit 1
 }
 
-
-echo -n "checking for intltoolize... "
+printf "%s" "checking for intltoolize... "
 which intltoolize || {
 	echo "*** No intltoolize found, please install it ***"
 	exit 1


### PR DESCRIPTION
`echo -n` is not a portable (POSIX compliant) way of printing a line with no trailing whitespace. On macOS for example the "-n" is literally printed to the terminal. Use `printf` instead.

**Before:**

```
-n checking for pkg-config...
/opt/local/bin/pkg-config
-n checking for autoreconf...
/opt/local/bin/autoreconf
-n checking for intltoolize...
/opt/local/bin/intltoolize
```

**After:**

```
checking for pkg-config... /opt/local/bin/pkg-config
checking for autoreconf... /opt/local/bin/autoreconf
checking for intltoolize... /opt/local/bin/intltoolize
```
