### PR TITLE
Support ImageMagick 7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,6 +94,12 @@ else
     )
   fi
   if test "x${with_magick}" = xImageMagick; then
+      PKG_CHECK_MODULES([IMAGEMAGICK7],
+          [ImageMagick >= 7.0.1],
+	 [HAVE_IMAGEMAGICK7=yes
+	  AC_DEFINE(HAVE_IMAGEMAGICK7, 1, [ImageMagick version 7 or higher is available.])
+	 ],[]
+	)
       PKG_CHECK_MODULES([IMAGEMAGICK],
          [ImageMagick >= 5.2.1],
 	 [HAVE_MAGICK=yes


### PR DESCRIPTION
* Detect IM7 at configure and define preprocesser macro when IM' is detected appropriately, because with IM7 we have to change header path to include
* Change header inclusion path for IM7
* GetExceptionInfo is deprecated (at least) in 6.9.12, replace with AcquireExceptionInfo
* InitializeMagick is deprecated (at least) in 6.9.12, it calls MagickCoreGenesis(path,MagickFalse) internally, so replace as such.
* GetImageType should be replaced with IdentifyImageType
* GetOnePixel should be replaced with GetOneAuthenticPixel. GetOneAuthenticPixel returns Quantum array, which must be passed to ScaleQuantumToChar.