### PR TITLE
Expected test failure without ImageMagick

### DIFF
--- a/tests/github-#70/run
+++ b/tests/github-#70/run
@@ -4,6 +4,16 @@
 
 DIR=$1
 
+# Check whether ImageMagick support is enabled and hence we support XPM
+autotrace -list-input-formats 2>&1 | grep xpm
+RESULT=$?
+
+if [ $RESULT -ne 0 ] ; then
+    XPM=0
+else
+    XPM=1
+fi
+
 autotrace -report-progress -centerline -input-format XPM $DIR/lego_5.xpm -output-format svg -output-file $DIR/lego_5.svg
 RESULT=$?
 
@@ -11,5 +21,9 @@ if [ $RESULT -eq 0 ] && [ -s $DIR/lego_5.svg ] ; then
     rm -f $DIR/lego_5.svg
     ok
 else
-    fail
+    if [ $XPM -eq 0 ] ; then
+        expected_fail
+    else
+        fail
+    fi
 fi


### PR DESCRIPTION
Maybe this can be done cleaner way, but it causes the run test not to fail without ImageMagick.
