### PR TITLE
Avoid GNU-specific xargs flags in tests/runtests.sh

### DIFF
--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -7,7 +7,7 @@
 cd `dirname "$0"`
 
 # Cleanup test remnants.
-find . -name '*.log' | xargs --no-run-if-empty -d\\n rm -v
+find . -name '*.log' -print -delete
 echo
 
 # Export custom location Autotrace binary if supplied.


### PR DESCRIPTION
In fact, avoid `xargs` entirely by using features built into `find` instead.

See #132

-----

Although this fixes the immediate problem and preserves the existing behavior of printing and then deleting any log files in the tests directory, it seems weird to me in a couple ways. First, why do you want to print the names of logfiles you're deleting? You could remove `-print` if you don't want to do that. Then, there were no log files after I ran the tests. Should there have been?