### PR TITLE
patch version for release build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 #
 # Author: Masatake YAMATO (yamato@redhat.com)
 #
-AC_INIT([autotrace],[0.40.0])
+AC_INIT([autotrace],[0.31.10])
 AC_CONFIG_SRCDIR([src/main.c])
 AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
For the 0.31.10 release build, the version output is 0.40.0, thus updating the configure.ac file to fix the version output issue.

relates to Homebrew/homebrew-core#168374

cc @lemenkov
